### PR TITLE
Update opts.c

### DIFF
--- a/src/squeue/opts.c
+++ b/src/squeue/opts.c
@@ -2178,7 +2178,7 @@ Usage: squeue [OPTIONS]\n\
                                   of one\n\
   -h, --noheader                  no headers on output\n\
       --hide                      do not display jobs in hidden partitions\n\
-  -i, --iterate=seconds           specify an interation period\n\
+  -i, --iterate=seconds           specify an iteration period\n\
   -j, --job=job(s)                comma separated list of jobs IDs\n\
                                   to view, default is all\n\
       --local                     Report information only about jobs on the\n\


### PR DESCRIPTION
In the squeue --help output, the -i option shows this:

   joe@slurm:~$ squeue --help | grep iter
  -i, --iterate=seconds           specify an **interation** period

This patch is trivial and removes the extra "n" in iteration.  Found while looking for the iteration feature in squeue.